### PR TITLE
[codex] Update qs transitive dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1191,8 +1191,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  body-parser@1.20.4:
-    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+  body-parser@1.20.5:
+    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   brace-expansion@1.1.13:
@@ -1701,8 +1701,8 @@ packages:
   express-urlrewrite@1.4.0:
     resolution: {integrity: sha512-PI5h8JuzoweS26vFizwQl6UTF25CAHSggNv0J25Dn/IKZscJHWZzPrI5z2Y2jgOzIaw2qh8l6+/jUcig23Z2SA==}
 
-  express@4.22.1:
-    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
 
   fast-deep-equal@3.1.3:
@@ -2564,8 +2564,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -4190,7 +4190,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  body-parser@1.20.4:
+  body-parser@1.20.5:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -4200,7 +4200,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -4874,11 +4874,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@4.22.1:
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.4
+      body-parser: 1.20.5
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
@@ -4897,7 +4897,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -5363,13 +5363,13 @@ snapshots:
 
   json-server@0.17.4:
     dependencies:
-      body-parser: 1.20.4
+      body-parser: 1.20.5
       chalk: 4.1.2
       compression: 1.8.1
       connect-pause: 0.1.1
       cors: 2.8.6
       errorhandler: 1.5.2
-      express: 4.22.1
+      express: 4.22.2
       express-urlrewrite: 1.4.0
       json-parse-helpfulerror: 1.0.3
       lodash: 4.18.1
@@ -5758,7 +5758,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## Summary

Updates the lockfile dependency chain used by `json-server` so `qs` resolves to the patched `6.15.2` release.

## Root Cause

Dependabot alert 128 flagged `qs@6.14.2` through development-only transitive dependencies. `body-parser@1.20.4` and `express@4.22.1` both constrained `qs` to `~6.14.0`, which is within the vulnerable range for GHSA-q8mj-m7cp-5q26 / CVE-2026-8723.

## Changes

- Updated `body-parser` lockfile resolution from `1.20.4` to `1.20.5`.
- Updated `express` lockfile resolution from `4.22.1` to `4.22.2`.
- Updated transitive `qs` resolution from `6.14.2` to `6.15.2`.

## Validation

- `pnpm list qs --depth 20`
- `node -e "const qs=require('./node_modules/.pnpm/qs@6.15.2/node_modules/qs'); console.log(require('./node_modules/.pnpm/qs@6.15.2/node_modules/qs/package.json').version); console.log(qs.stringify({a:[null,'b']},{arrayFormat:'comma',encodeValuesOnly:true})); console.log(qs.stringify({a:[undefined,'b']},{arrayFormat:'comma',encodeValuesOnly:true}))"`
- `pnpm exec vite build`
- `git diff --check`
- `pnpm audit --prod --audit-level moderate`